### PR TITLE
Fix negative runtime issue

### DIFF
--- a/simulation_experiments.py
+++ b/simulation_experiments.py
@@ -26,7 +26,7 @@ def solve_problem(problem, observations, method, solver='MOSEK'):
     try:
         t_start = time.time()
         sdr.solve(solver=solver, warm_start=False, **solver_params)
-        t = t_start - time.time()
+        t = time.time() - t_start 
         results = sdr.get_solution(eps=1e-4)
         cost = triangulation.robust_cost(
             point=results["estimated_point"],


### PR DESCRIPTION
In the `simulation_experiments.py`, the measured time of `sdr.solve` is calculated as `t_start - time.time()` which makes the time `t` a negative value. This PR simply fixes it by swapping `t_start` and `time.time()` to correct the sign.